### PR TITLE
Added the option to read from stdin

### DIFF
--- a/newsfragments/+d56c61cc.feature.rst
+++ b/newsfragments/+d56c61cc.feature.rst
@@ -1,0 +1,1 @@
+Added the option to read from stdin.

--- a/oathtool/__init__.py
+++ b/oathtool/__init__.py
@@ -69,9 +69,15 @@ def generate_otp(key, hotp_value=None):
 
 def main():
     try:
-        (key,) = sys.argv[1:]
-    except ValueError:
-        print('provide secret key as only arg')
-        sys.exit(1)
+        if sys.stdin.isatty():
+            # If stdin is not being piped, read from command-line argument
+            (key,) = sys.argv[1:]
+        else:
+            # Read from standard input (pipe)
+            key = sys.stdin.read().strip()
 
+        print(generate_otp(key))
+    except ValueError:
+        print('provide secret key as only arg or via stdin')
+        sys.exit(1)
     print(generate_otp(key))

--- a/oathtool/__init__.py
+++ b/oathtool/__init__.py
@@ -67,16 +67,22 @@ def generate_otp(key, hotp_value=None):
     )
 
 
+def _one(items):
+    (item,) = items
+    return item
+
+
+def get_key_arg():
+    return _one(sys.argv[1:])
+
+
+def get_key_stdin():
+    return not sys.stdin.isatty() and sys.stdin.read().strip()
+
+
 def main():
     try:
-        if sys.stdin.isatty():
-            # If stdin is not being piped, read from command-line argument
-            (key,) = sys.argv[1:]
-        else:
-            # Read from standard input (pipe)
-            key = sys.stdin.read().strip()
-
-        print(generate_otp(key))
+        key = get_key_stdin() or get_key_arg()
     except ValueError:
         print('provide secret key as only arg or via stdin')
         sys.exit(1)

--- a/oathtool/test_oathtool.py
+++ b/oathtool/test_oathtool.py
@@ -3,9 +3,11 @@ import subprocess
 
 import pytest
 
+test_key = 'MZXW6YTBOJUWU23MNU'
+
 
 def test_execution():
-    cmd = [sys.executable, '-m', 'oathtool', 'MZXW6YTBOJUWU23MNU']
+    cmd = [sys.executable, '-m', 'oathtool', test_key]
     subprocess.check_call(cmd)
 
 
@@ -20,3 +22,8 @@ def test_generate_script(tmpdir):
     cmd = [sys.executable, '-m', 'oathtool.generate-script', str(target)]
     subprocess.check_call(cmd)
     assert target.isfile()
+
+
+def test_piped_input():
+    cmd = [sys.executable, '-m', 'oathtool']
+    subprocess.run(cmd, input=test_key, check=True, text=True, encoding='utf-8')


### PR DESCRIPTION
With this change we will be able to pass the key from standard input like this:

```shell
cat file | oathtool
# or 
oathtool < file
```

This is much more useful inside containers and sandboxes due to the way secrets are mounted there